### PR TITLE
add functionality

### DIFF
--- a/lib/HttpTest.js
+++ b/lib/HttpTest.js
@@ -93,25 +93,6 @@ module.exports = oo({
       }
     }
 
-    var endpoint = _o(url)
-    if (typeof(test) === 'function') {
-      return endpoint._performOperation(reqSpec.method.toLowerCase(), [
-        reqSpec.body, 
-        { 
-          params: reqSpec.parameters,
-          headers: reqSpec.headers,
-          json: reqSpec.json,
-          strictSSL: reqSpec.strictSSL
-        }, 
-        function(err, response) {  
-          if (err) {
-            return cb(err, null)
-          }
-          assert(test(response))
-        }
-      ])
-    }
-    
     if (typeof(reqSpec) === 'function') {
       return this._executeHttpTest({ reqSpec: reqSpec(previousResponse), 
                                      resSpec: resSpec 
@@ -119,11 +100,11 @@ module.exports = oo({
                                    previousResponse, cb)
     }
 
-
     if (!reqSpec.method) {
       return cb(new Error("Request spec must provide a method."))
     }
 
+    var endpoint = _o(url)
     // XXX want better method to invoke here. This is private and hacky
     return endpoint._performOperation(reqSpec.method.toLowerCase(), [
       reqSpec.body, 

--- a/lib/HttpTest.js
+++ b/lib/HttpTest.js
@@ -30,13 +30,20 @@ module.exports = oo({
    * _init
    */
   _init: function() {
+    Test.prototype._init.call(this)
+  },
+
+  /**********************************************************************
+   * _initTests
+   */
+  _initTests: function() {
     var self = this
 
     var result = []
     var previousResponse = undefined // This is a nice use of a closure. See what we are doing here?
     _.forEach(self.tests, function(test) {
       if (!(test instanceof Test)) {
-        test = o({
+        var _test = {
           _type: Test,
           name: `${test.reqSpec.method} ${test.reqSpec.url}`,
           reqSpec: test.reqSpec,
@@ -44,12 +51,21 @@ module.exports = oo({
           doTest: function() {
             previousResponse = self.sync._executeHttpTest(test, previousResponse)
           }
-        })
+        }
+        if (test.setup) {
+          _test.setup = test.setup
+        }
+        if (test.teardown) {
+          _test.teardown = test.teardown
+        }
+        test = o(_test)
       }
       result.push(test)
     })
 
     self.tests = result
+
+    Test.prototype._initTests.call(this)
   },
 
   /**********************************************************************
@@ -94,7 +110,7 @@ module.exports = oo({
     }
 
     if (typeof(reqSpec) === 'function') {
-      return this._executeHttpTest({ reqSpec: reqSpec(previousResponse), 
+      return this._executeHttpTest({ reqSpec: reqSpec.call(test, previousResponse),
                                      resSpec: resSpec 
                                    },
                                    previousResponse, cb)
@@ -121,13 +137,13 @@ module.exports = oo({
 
         try {
           if (typeof(resSpec) === 'function') {
-            assert.ok(resSpec(response), "Assertion failed for test: " + EJSON.stringify(test))
+            assert.ok(resSpec.call(test, response), "Assertion failed for test: " + EJSON.stringify(test))
           }
 
           _.forEach(resSpec, function(valueSpec, fieldName) {
             var value = response[fieldName]
             if (typeof(valueSpec) === 'function') {
-              assert.ok(valueSpec(value), 
+              assert.ok(valueSpec.call(test, value),
                         "Assertion failed for field '" 
                         + fieldName + " with value '" + value, EJSON.stringify(test))
             } else {

--- a/lib/Test.js
+++ b/lib/Test.js
@@ -9,7 +9,7 @@ var path = require('path')
 /******************************************************************************
  * @class Test
  */
-module.exports = oo({
+var Test = oo({
 
   /**********************************************************************
    * _C
@@ -17,6 +17,7 @@ module.exports = oo({
   _C: function() {
     this.name = path.basename(module.filename, path.extname(module.filename)) // name of this file without ext
     this.tests = []
+    this.parent = undefined
     this.description = undefined
     this.errorExpected = false
     this.selfBeforeChildren = false
@@ -26,6 +27,42 @@ module.exports = oo({
    * _init
    */
   _init: function() {
+    this._initTests()
+  },
+
+  /**********************************************************************
+   * _initTests
+   */
+  _initTests: function() {
+    var self = this
+    if (this.tests) {
+      this.tests.forEach(function(test) {
+        test.parent = self
+      })
+    }
+  },
+
+  /**********************************************************************
+   * toJSON
+   */
+  toJSON: function() {
+    return {
+      name: this.name,
+      tests: this.tests,
+      description: this.description,
+      errorExpected: this.errorExpected,
+      selfBeforeChildren: this.selfBeforeChildren
+    }
+  },
+
+  /**********************************************************************
+   * serialize
+   *
+   * @note expected by https://github.com/mongodb-js/extended-json
+   *
+   */
+  serialize: function() {
+    return this.toJSON()
   },
 
   /**********************************************************************
@@ -264,4 +301,4 @@ module.exports = oo({
   }
 })
 
-
+module.exports = Test

--- a/test/HttpTestTests.js
+++ b/test/HttpTestTests.js
@@ -9,7 +9,7 @@ var assert = require('assert')
  */
 var url = "http://pastebin.com/raw/ewNZGrjd"
 
-module.exports = o({
+var HttpTestTests = o({
 
   /**********************************************************************
    * _type
@@ -50,7 +50,10 @@ module.exports = o({
         method: "GET"
       },
       resSpec: {
-        statusCode: function(statusCode) { return statusCode === 200 },
+        statusCode: function(statusCode) {
+          assert.equal(this.parent, HttpTestTests)
+          return statusCode === 200
+        },
         body: {
           a: 1,
           b: "hello",
@@ -63,10 +66,14 @@ module.exports = o({
         url: url,
         method: "GET"
       },
-      resSpec: function(res) { return res.statusCode === 200 },
+      resSpec: function(res) {
+        assert.equal(this.parent, HttpTestTests)
+        return res.statusCode === 200
+      },
     },
     {
       reqSpec: function(prevResponse) {
+        assert.equal(this.parent, HttpTestTests)
         assert(prevResponse.body.a === 1)
         return {
           url: url,
@@ -84,6 +91,48 @@ module.exports = o({
         statusCode: 404
       },
     },
+    o({
+      _type: '../lib/Test',
+      name: 'TestSetupTeardownHooks',
+      description: 'Test HttpTest child test setup/teardown hooks',
+      doTest: function() {
+        var testSuite = o({
+          _type: '../lib/HttpTest',
+          _C: function() {
+            this.setupCalled = false
+            this.teardownCalled = false
+          },
+          baseUrl: "http://pastebin.com/raw",
+          tests: [
+            {
+              setup: function() {
+                this.parent.setupCalled = true
+              },
+              teardown: function() {
+                this.parent.teardownCalled = true
+              },
+              reqSpec: {
+                url: url,
+                method: "GET"
+              },
+              resSpec: {
+                statusCode: 200,
+                body: {
+                  a: 1,
+                  b: "hello",
+                  c: [ true, false ]
+                }
+              }
+            }
+          ]
+        })
+        var result = testSuite.run()
+        assert(result.passed)
+        assert(testSuite.setupCalled)
+        assert(testSuite.teardownCalled)
+      }
+    })
   ]
 })
 
+module.exports = HttpTestTests

--- a/test/TestTests.js
+++ b/test/TestTests.js
@@ -1,0 +1,34 @@
+var assert = require('assert')
+
+var EJSON = require('ejson')
+var o = require('atom').o(module).main
+
+/******************************************************************************
+ * TestTests
+ */
+module.exports = o({
+
+  /**********************************************************************
+   * _type
+   */
+  _type: '../lib/Test',
+
+  /**********************************************************************
+   * name
+   */
+  name: "TestTests",
+
+  /**********************************************************************
+   * tests
+   */
+  tests: [
+    o({
+      _type: '../lib/Test',
+      name: 'EJSONStringifyWithCircularReferenceTest',
+      description: 'Test EJSON#stringify works with circular parent reference',
+      doTest: function() {
+        assert.equal(EJSON.stringify(this), JSON.stringify(this))
+      }
+    })
+  ]
+})

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ module.exports = o({
   _type: Test,
   name: "Testtube Tests",
   tests: [
+    _o('./TestTests'),
     _o('./OrderingTests'),
     _o('./HttpTestTests')
   ]


### PR DESCRIPTION
- remove dead code from HttpTest (if test is a function)
- add setup/teardown hooks to req/res specs
- add parent link to child tests
- bind calls to res/req specs to the Test instance if they happen to be functions
- add toJSON/serialize methods to Test to deal with circular reference introduced by the parent link