### PR TITLE
Fix description for Http Tests

### DIFF
--- a/lib/HttpTest.js
+++ b/lib/HttpTest.js
@@ -96,6 +96,7 @@ module.exports = oo({
       var _test = {
         _type: Test,
         name: testName,
+        description: test.description,
         errorExpected: test.errorExpected,
         reqSpec: test.reqSpec,
         resSpec: test.resSpec,


### PR DESCRIPTION
Descriptions were set to undefined and weren't printed in test reports.